### PR TITLE
escape sql special characters

### DIFF
--- a/common/mysql/mysql.go
+++ b/common/mysql/mysql.go
@@ -164,7 +164,9 @@ func (self *MyTable) FlushInsert() error {
 	for _, row := range self.rows {
 		self.sqlCode += `(`
 		for _, v := range row {
+			v = strings.Replace(v, `\`, `\\`, -1)
 			v = strings.Replace(v, `"`, `\"`, -1)
+			v = strings.Replace(v, `'`, `\'`, -1)
 			self.sqlCode += `"` + v + `",`
 		}
 		self.sqlCode = self.sqlCode[:len(self.sqlCode)-1] + `),`


### PR DESCRIPTION
It is not enough to just escape "double quote". I have added "backslash" and "single quote" as well for my cases

https://github.com/go-sql-driver/mysql/blob/master/utils.go#L606-L652
