### PR TITLE
Avoid removing too many extensions

### DIFF
--- a/app/spider/context.go
+++ b/app/spider/context.go
@@ -230,15 +230,18 @@ func (self *Context) FileOutput(name ...string) {
 	_, s := path.Split(self.GetUrl())
 	n := strings.Split(s, "?")[0]
 
-	baseName := strings.Split(n, ".")[0]
+	var baseName, ext string
 
-	var ext string
 	if len(name) > 0 {
 		p, n := path.Split(name[0])
-		if baseName2 := strings.Split(n, ".")[0]; baseName2 != "" {
+		ext = path.Ext(n)
+		if baseName2 := strings.TrimSuffix(n, ext); baseName2 != "" {
 			baseName = p + baseName2
 		}
+	}
+	if baseName == "" {
 		ext = path.Ext(n)
+		baseName = strings.TrimSuffix(n, ext)
 	}
 	if ext == "" {
 		ext = path.Ext(n)


### PR DESCRIPTION
某些文件会有多个后缀名，比如 `xxx.json.zip`，`xxx.1_2.json`。
由于 `path.Ext` 只返回最后一个后缀名，如果只保留`.`分割的第一个部分和后缀名，那么下载下来的文件会少中间的部分。这个 pr 修改了下截取逻辑，避免后缀名丢失的问题。