### PR TITLE
proxy代理验证方式

### DIFF
--- a/app/aid/proxy/proxy.go
+++ b/app/aid/proxy/proxy.go
@@ -201,7 +201,6 @@ func (self *Proxy) testAndSort(key string, testHost string) (*ProxyForHost, bool
 		}
 		self.threadPool <- true
 		go func(proxy string) {
-			//alive, timedelay := self.findUsable(proxy, testHost)
 			alive, timedelay := self.findUsable(proxy, testHost)
 			if alive {
 				proxyForHost.Mutex.Lock()
@@ -237,27 +236,10 @@ func (self *Proxy) findUsable(proxy string, testHost string) (alive bool, timede
 	}
 	req.SetProxy(proxy)
 	resp, err := self.surf.Download(req)
-	if err != nil {
-		return false, 0
-	}
 
 	if resp.StatusCode != http.StatusOK {
 		return false, 0
 	}
 
-	return true, time.Since(t0)
-}
-
-func (self *Proxy) findUsable2(proxy string) (alive bool, timedelay time.Duration) {
-	t0 := time.Now()
-	req := &request.Request{
-		Url:         "http://httpbin.org/",
-		Method:      "GET",
-		DialTimeout: time.Second * time.Duration(DAIL_TIMEOUT),
-		ConnTimeout: time.Second * time.Duration(CONN_TIMEOUT),
-		TryTimes:    TRY_TIMES,
-	}
-	req.SetProxy(proxy)
-	_, err := self.surf.Download(req)
 	return err == nil, time.Since(t0)
 }

--- a/app/aid/proxy/proxy.go
+++ b/app/aid/proxy/proxy.go
@@ -101,7 +101,6 @@ func (self *Proxy) findOnline() *Proxy {
 		self.threadPool <- true
 		go func(proxy string) {
 			alive, _, _ := ping.Ping(self.allIps[proxy], CONN_TIMEOUT)
-			log.Println("liguoqinjim ping", self.allIps[proxy])
 			self.Lock()
 			self.all[proxy] = alive
 			self.Unlock()
@@ -203,7 +202,7 @@ func (self *Proxy) testAndSort(key string, testHost string) (*ProxyForHost, bool
 		self.threadPool <- true
 		go func(proxy string) {
 			//alive, timedelay := self.findUsable(proxy, testHost)
-			alive, timedelay := self.findUsable2(proxy)
+			alive, timedelay := self.findUsable(proxy, testHost)
 			if alive {
 				proxyForHost.Mutex.Lock()
 				proxyForHost.proxys = append(proxyForHost.proxys, proxy)
@@ -237,8 +236,16 @@ func (self *Proxy) findUsable(proxy string, testHost string) (alive bool, timede
 		TryTimes:    TRY_TIMES,
 	}
 	req.SetProxy(proxy)
-	_, err := self.surf.Download(req)
-	return err == nil, time.Since(t0)
+	resp, err := self.surf.Download(req)
+	if err != nil {
+		return false, 0
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return false, 0
+	}
+
+	return true, time.Since(t0)
 }
 
 func (self *Proxy) findUsable2(proxy string) (alive bool, timedelay time.Duration) {


### PR DESCRIPTION
1.之前只能输入`http://ip:port`这样的格式的代理。
但是有的动态代理的格式是`http://username:password@abc.com:1234`这样的，现在这种格式的代理也可以通过第一步检测。
2.在启动爬虫的时候，之前验证代理的方法是用HEAD的方式走代理去访问一次url判断是否成功，这次加了一步，会判断返回的状态码是否为200。