### PR TITLE
common/bytes: remove duplicated switch case

### DIFF
--- a/common/bytes/bytes.go
+++ b/common/bytes/bytes.go
@@ -43,9 +43,6 @@ func (*Bytes) Format(b uint64) string {
 	case b < MB:
 		value /= KB
 		multiple = "KB"
-	case b < MB:
-		value /= KB
-		multiple = "KB"
 	case b < GB:
 		value /= MB
 		multiple = "MB"


### PR DESCRIPTION
The `b < MB` case was repeated twice.