### PR TITLE
给请求手动设置代理

### DIFF
--- a/app/scheduler/matrix.go
+++ b/app/scheduler/matrix.go
@@ -120,6 +120,9 @@ func (self *Matrix) Pull() (req *request.Request) {
 		if len(self.reqs[idx]) > 0 {
 			req = self.reqs[idx][0]
 			self.reqs[idx] = self.reqs[idx][1:]
+			if req.GetProxy() != "" {
+				return
+			}
 			if sdl.useProxy {
 				req.SetProxy(sdl.proxy.GetOne(req.GetUrl()))
 			} else {


### PR DESCRIPTION
手动设置代理。

```go
req := &request.Request{
	Url:          "https://www.baidu.com",
	Method:  "GET",
	Rule:        "detail",
}
req.SetProxy("https://1.1.1.1")
ctx.AddQueue(req)				
```