### PR TITLE
增加注册outType,手动处理pipe

### DIFF
--- a/app/pipeline/collector/output_data.go
+++ b/app/pipeline/collector/output_data.go
@@ -49,3 +49,8 @@ func (self *Collector) outputData() {
 		self.Spider.TryFlushSuccess()
 	}
 }
+
+// 注册output
+func Register(outType string, outFunc func(self *Collector) (err error)) {
+	DataOutput[outType] = outFunc
+}


### PR DESCRIPTION
在项目可能会用其他不同存储，加入自定义type，可以把逻辑交给外部处理

```go
package demo

import(
    "github.com/henrylee2cn/pholcus/app/pipeline/collector"
)
func init() {
	collector.Register("test", TestPipe)
}

func TestPipe(self *collector.Collector) (error)  {
	var dataCollects = make(map[string][]interface{})
	for _, datacell := range self.GetDataDocker() {
		rule := datacell["RuleName"].(string)
		data := datacell["Data"].(map[string]interface{})
		dataCollects[rule] = append(dataCollects[rule], data)
	}
	//其他逻辑
	return nil
}

```

在`config.ini`文件中配置
```ini
outtype=test
```