### PR TITLE
fix(sec): upgrade github.com/tidwall/match to 1.0.3

### DIFF
--- a/vendor/github.com/tidwall/gjson/go.mod
+++ b/vendor/github.com/tidwall/gjson/go.mod
@@ -3,6 +3,6 @@ module github.com/tidwall/gjson
 go 1.12
 
 require (
-	github.com/tidwall/match v1.0.1
+	github.com/tidwall/match v1.0.3
 	github.com/tidwall/pretty v1.0.0
 )

--- a/vendor/github.com/tidwall/gjson/go.sum
+++ b/vendor/github.com/tidwall/gjson/go.sum
@@ -1,4 +1,6 @@
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/tidwall/match v1.0.1
- [CVE-2020-36066](https://www.oscs1024.com/hd/CVE-2020-36066)


### What did I do？
Upgrade github.com/tidwall/match from v1.0.1 to 1.0.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS